### PR TITLE
0.7.1 : accepter absence de valeur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,18 @@
 
 Ce fichier répertorie les changements entre différentes versions d'un schéma.
 
+## Version 0.7.1 - 2021-10-18
 
-## Version 0.5.0 - 2021-06-11
+Adaptation du schéma pour :
+- accepter la valeur `null` pour les champs `*_critair` et `*_horaires` lorsque la réglementation locale ne prévoit pas de mesure pour ce type de véhicules
+- rendre obligatoire la saisie du champ `_horaire` associé au champ `_critair` lorsque celui-ci est renseigné (et vice-versa)
 
-Publication initiale 
+
+## Version 0.7.0 - 2021-07-01
+
+Modifications importantes de la structure du schéma :
+- suppression des champs : proprietaire_vehicule, taxi_critair, taxi_horaires
+- modification des modalités des vignettes pour correspondre à la codification retenue par l'Imprimerie nationale (IN) pour devenir : EL, V1, V2, V3, V4, V5, NC
 
 ## Version 0.6.0 - 2021-07-01
 
@@ -13,9 +21,6 @@ Modifications importantes de la structure du schéma :
 - format CSV vers format GeoJSON
 - un seul schéma pour décrire les aires réglementées et les voies spéciales 
 
+## Version 0.5.0 - 2021-06-11
 
-## Version 0.7.0 - 2021-07-01
-
-Modifications importantes de la structure du schéma : 
-- suppression des champs : proprietaire_vehicule, taxi_critair, taxi_horaires
-- modification des modalités des vignettes pour correspondre à la codification retenue par l'Imprimerie nationale (IN) pour devenir : EL, V1, V2, V3, V4, V5, NC
+Publication initiale

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Ce schéma permet de modéliser les règles de limitation de circulation sur une
 
 Dans le cadre des travaux de l’équipe du Point d’accès national et de la mise en oeuvre de l’ouverture des données pour améliorer l’information dont disposent les voyageurs, l’équipe de transport.data.gouv.fr propose une solution simple et structurée pour l’ouverture des données concernant les Zones à Faibles Emissions : la Base Nationale des Zones à Faibles Emissions (BNZFE). 
 
-Le schéma de la base de données a été co-construit avec les collectivités, leurs services SIG et avec les futurs réutilisateurs de ces données. Des ateliers avec ces acteurs et un atelier ouvert (le 08/04/2021) ont permis sa production. Aujourd’hui disponible en version 0.6.0, il sera mis-à-jour régulièrement.
+Le schéma de la base de données a été co-construit avec les collectivités, leurs services SIG et avec les futurs réutilisateurs de ces données. Des ateliers avec ces acteurs et un atelier ouvert (le 08/04/2021) ont permis sa production. Aujourd’hui disponible en version 0.7.1, il sera mis-à-jour régulièrement.
 
 ## Cadre juridique
 
@@ -21,10 +21,10 @@ La base présente plusieurs cas d’usage
 
 Le fichier précise notamment : 
 - l'identifiant d'une aire concernée par une réglementation ZFE ou l'identifiant d'un tronçon routier concerné par une règle exceptionnelle ;
-- la date de mise en place du dispositif et la date à laquelle la règlementation prend fin ;
+- la date de mise en place du dispositif et la date à laquelle la réglementation prend fin ;
 - la catégorie de conducteurs concernée par le dispositif (personne morale et/ou physique) ;
-- les vignettes CRITAIR autorisées par type de véhicule (véhicule particuliers, utiliraires, poids lourds, autobus, deux roues, taxis...) ;
-- les horaires d'application par type de véhicules (véhicule particuliers, utiliraires, poids lourds, autobus, deux roues, taxis...) ;
+- les vignettes CRITAIR autorisées par type de véhicule (véhicule particuliers, utilitaires, poids lourds, autobus, deux roues, taxis...) ;
+- les horaires d'application par type de véhicules (véhicule particuliers, utilitaires, poids lourds, autobus, deux roues, taxis...) ;
 - l'arrêté associé ;
 - le site d'information associé à la réglementation.
 
@@ -47,8 +47,8 @@ Les producteurs pourront :
 - publier directement sur data.gouv.fr ;
 - publier sur un portail local ou régional et s'assurer que les données publiées sont bien moissonnées et référencées sur data.gouv.fr.
 
-Nous préconisons aux producteurs de données de publier leurs fichiers cocnernant les zones avec la règle de nommage suivante : zfe_zone_nom.geojson avec nom étant le nom de la collectivité productrice des données, par exemple zfe_zone_grenoble.geojson. 
-Pour les fichiers concernant les voies spéciales : zfe_voie_speciale_nom.geojson, avec nom étant le nom de la collectivité productrice des données, par exemple zfe_voie_speciale_grenoble.geojson. 
+Nous préconisons aux producteurs de données de publier leurs fichiers concernant les zones avec la règle de nommage suivante : `zfe_zone_nom.geojson` avec nom étant le nom de la collectivité productrice des données, par exemple `zfe_zone_grenoble.geojson`.
+Pour les fichiers concernant les voies spéciales : `zfe_voie_speciale_nom.geojson`, avec nom étant le nom de la collectivité productrice des données, par exemple `zfe_voie_speciale_grenoble.geojson`.
 
 En cas de mise à jour d’un fichier déjà intégré à la base consolidée, il est recommandé de prévenir l’équipe transport.data.gouv.fr qui s’assurera de l'actualisation du fichier en question et de son intégration dans la base consolidée.
 
@@ -69,13 +69,7 @@ Comme expliqué ce schéma de données permet de décrire des aires réglementé
 Comme indiqué dans les métadonnées, le fichier et ses mises-à-jour sont distribués sous la Licence Ouverte Etalab 2.0. Cela signifie que vous pouvez télécharger librement cette base, la réutiliser, la modifier, l’utiliser commercialement, etc, tant que vous en mentionnez la source (par exemple dans les mentions légales de votre application).
 Nous tenons à remercier les membres du groupe de travail pour leur investissement dans l'élaboration de ce schéma.
 
-## Notes techniques pour contribuer à ce schéma
-
-Ce schéma s'appuie sur [TableSchema](https://specs.frictionlessdata.io/table-schema/). Pour le modifier, il peut être utile en particulier de se référer à la [spécification des descripteurs de champs](https://specs.frictionlessdata.io/table-schema/#field-descriptors).
-
 ### Fichiers disponibles
-
-Ce dépôt contient un ensemble de fichiers utiles pour un dépôt d'un schéma [Table Schema](https://specs.frictionlessdata.io/table-schema/).
 
 - [`CHANGELOG.md`](https://github.com/etalab/schema-zfe/blob/master/CHANGELOG.md) contient la liste des changements entre les différentes versions du schéma ;
 - [`exemple-valide-zone.geojson`](https://github.com/etalab/schema-zfe/blob/master/exemple-valide-zone.geojson) est un fichier GeoJSON d'exemple conforme décrivant une aire par rapport au schéma décrit dans `schema.json`  ;
@@ -83,7 +77,7 @@ Ce dépôt contient un ensemble de fichiers utiles pour un dépôt d'un schéma 
 - [`LICENSE.md`](https://github.com/etalab/schema-zfe/blob/master/LICENSE.md) est le fichier de licence du dépôt ;
 - [`README.md`](https://github.com/etalab/schema-zfe/blob/master/README.md) est le fichier que vous lisez actuellement ;
 - [`requirements.txt`](https://github.com/etalab/schema-zfe/blob/master/requirements.txt) liste les dépendances Python nécessaires pour effectuer des tests en intégration continue sur le dépôt ;
-- [`schema.json`](https://github.com/etalab/schema-zfe/blob/master/schema.json) est le schéma au format Table Schema.
+- [`schema.json`](https://github.com/etalab/schema-zfe/blob/master/schema.json) est le schéma au format [JSON Schema](https://json-schema.org/).
 
 ### Intégration continue
 
@@ -93,5 +87,3 @@ Ce dépôt est configuré pour utiliser de l'intégration continue, si vous util
 - que vos fichiers d'exemples sont conformes au schéma.
 
 Vous pouvez consulter la configuration utilisée dans [`.github/workflows/test.yml`](.github/workflows/test.yml).
-
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-jsonschema==3.2.0
+jsonschema==4.1.0

--- a/schema.json
+++ b/schema.json
@@ -43,7 +43,7 @@
                 ]
               },
               "vp_critair": {
-                "type": "string",
+                "type": ["string", "null"],
                 "description": "Véhicules particuliers : Vignette CRITAIR à partir de laquelle la circulation n'est pas autorisée. Par exemple V4 signifie que les véhicules CRITAIR 4, CRITAIR 5 et sans vignettes ne sont pas autorisés à circuler. L'ordre des vignettes est le suivant : EL, V1, V2, V3, V4, V5, NC. EL correspond aux véhicules électriques et NC aux véhicules sans vignette.",
                 "examples": [
                   "V4"
@@ -53,13 +53,14 @@
                   "V4",
                   "V3",
                   "V2",
-                  "V1", 
+                  "V1",
                   "EL",
-		  "NC"
+                  "NC",
+                  null
                 ]
               },
               "vp_horaires": {
-                "type": "string",
+                "type": ["string", "null"],
                 "description": "Véhicules particuliers : jours et horaires de restriction au format 'opening hours' d'OpenStreetMap : https://wiki.openstreetmap.org/wiki/Key:opening_hours",
                 "examples": [
                   "Mo-Fr 08:00-20:00; PH off",
@@ -67,7 +68,7 @@
                 ]
               },
               "vul_critair": {
-                "type": "string",
+                "type": ["string", "null"],
                 "description": "Véhicules utilitaires légers : Vignette CRITAIR à partir de laquelle la circulation n'est pas autorisée. Par exemple V4 signifie que les véhicules CRITAIR 4, CRITAIR 5 et sans vignettes ne sont pas autorisés à circuler. L'ordre des vignettes est le suivant : EL, V1, V2, V3, V4, V5, NC. EL correspond aux véhicules électriques et NC aux véhicules sans vignette.",
                 "examples": [
                   "V4"
@@ -77,13 +78,14 @@
                   "V4",
                   "V3",
                   "V2",
-                  "V1", 
+                  "V1",
                   "EL",
-		  "NC"
+                  "NC",
+                  null
                 ]
               },
               "vul_horaires": {
-                "type": "string",
+                "type": ["string", "null"],
                 "description": "Véhicules utilitaires légers : jours et horaires de restriction au format 'opening hours' d'OpenStreetMap : https://wiki.openstreetmap.org/wiki/Key:opening_hours",
                 "examples": [
                   "Mo-Fr 08:00-20:00; PH off",
@@ -91,7 +93,7 @@
                 ]
               },
               "pl_critair": {
-                "type": "string",
+                "type": ["string", "null"],
                 "description": "Poids lourds (>3,5t): Vignette CRITAIR à partir de laquelle la circulation n'est pas autorisée. Par exemple V4 signifie que les véhicules CRITAIR 4, CRITAIR 5 et sans vignettes ne sont pas autorisés à circuler. L'ordre des vignettes est le suivant : EL, V1, V2, V3, V4, V5, NC. EL correspond aux véhicules électriques et NC aux véhicules sans vignette.",
                 "examples": [
                   "V4"
@@ -101,13 +103,14 @@
                   "V4",
                   "V3",
                   "V2",
-                  "V1", 
+                  "V1",
                   "EL",
-		  "NC"
+                  "NC",
+                  null
                 ]
               },
               "pl_horaires": {
-                "type": "string",
+                "type": ["string", "null"],
                 "description": "Poids lourds (>3,5t): jours et horaires de restriction au format 'opening hours' d'OpenStreetMap : https://wiki.openstreetmap.org/wiki/Key:opening_hours",
                 "examples": [
                   "Mo-Fr 08:00-20:00; PH off",
@@ -115,7 +118,7 @@
                 ]
               },
               "autobus_autocars_critair": {
-                "type": "string",
+                "type": ["string", "null"],
                 "description": "Autobus et autocars : Vignette CRITAIR à partir de laquelle la circulation n'est pas autorisée. Par exemple V4 signifie que les véhicules CRITAIR 4, CRITAIR 5 et sans vignettes ne sont pas autorisés à circuler. L'ordre des vignettes est le suivant : EL, V1, V2, V3, V4, V5, NC. EL correspond aux véhicules électriques et NC aux véhicules sans vignette.",
                 "examples": [
                   "V4"
@@ -125,13 +128,14 @@
                   "V4",
                   "V3",
                   "V2",
-                  "V1", 
+                  "V1",
                   "EL",
-		  "NC"
+                  "NC",
+                  null
                 ]
               },
               "autobus_autocars_horaires": {
-                "type": "string",
+                "type": ["string", "null"],
                 "description": "Autobus et autocars : jours et horaires de restriction au format 'opening hours' d'OpenStreetMap : https://wiki.openstreetmap.org/wiki/Key:opening_hours",
                 "examples": [
                   "Mo-Fr 08:00-20:00; PH off",
@@ -139,7 +143,7 @@
                 ]
               },
               "deux_rm_critair": {
-                "type": "string",
+                "type": ["string", "null"],
                 "description": "Deux roues, tricycles et quadricycles à moteur : Vignette CRITAIR à partir de laquelle la circulation n'est pas autorisée. Par exemple V4 signifie que les véhicules CRITAIR 4, CRITAIR 5 et sans vignettes ne sont pas autorisés à circuler. L'ordre des vignettes est le suivant : EL, V1, V2, V3, V4, V5, NC. EL correspond aux véhicules électriques et NC aux véhicules sans vignette.",
                 "examples": [
                   "V4"
@@ -149,13 +153,14 @@
                   "V4",
                   "V3",
                   "V2",
-                  "V1", 
+                  "V1",
                   "EL",
-		  "NC"
+                  "NC",
+                  null
                 ]
               },
               "deux_rm_horaires": {
-                "type": "string",
+                "type": ["string", "null"],
                 "description": "Deux roues, tricycles et quadricycles à moteur : jours et horaires de restriction au format 'opening hours' d'OpenStreetMap : https://wiki.openstreetmap.org/wiki/Key:opening_hours",
                 "examples": [
                   "Mo-Fr 08:00-20:00; PH off",
@@ -183,7 +188,19 @@
               "id",
               "date_debut",
               "url_arrete"
-            ]
+            ],
+            "dependentRequired": {
+              "vp_critair": ["vp_horaires"],
+              "vul_critair": ["vul_horaires"],
+              "pl_critair": ["pl_horaires"],
+              "autobus_autocars_critair": ["autobus_autocars_horaires"],
+              "deux_rm_critair": ["deux_rm_horaires"],
+              "vp_horaires": ["vp_critair"],
+              "vul_horaires": ["vul_critair"],
+              "pl_horaires": ["pl_critair"],
+              "autobus_autocars_horaires": ["autobus_autocars_critair"],
+              "deux_rm_horaires": ["deux_rm_critair"]
+            }
           }
         }
       }


### PR DESCRIPTION
Cette PR contient les changements suivants :

- la possibilité de renseigner les valeurs `null` pour les champs `*_critair` et `*_horaires`
- rendre obligatoire la saisie d'un champ `_horaire` si le champ `_critair` associé a été rempli (et vice-versa)
- un nettoyage du README
- un ordre antichronologique pour le CHANGELOG