### PR TITLE
Renomme dependentRequired en dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 Ce fichier répertorie les changements entre différentes versions d'un schéma.
 
+## Version 0.8.2 - 2022-04-28
+
+- adaptation de la façon de vérifier la présence des paires de champs `*_critair` et `*_horaires` introduite dans la version 0.7.1
+
 ## Version 0.8.1 - 2022-04-08
-- le champ "url_arrete" devient optionnel
+- le champ `url_arrete` devient optionnel
 
 ## Version 0.7.2 - 2021-12-21
 

--- a/schema.json
+++ b/schema.json
@@ -188,7 +188,7 @@
               "id",
               "date_debut"
             ],
-            "dependentRequired": {
+            "dependencies": {
               "vp_critair": ["vp_horaires"],
               "vul_critair": ["vul_horaires"],
               "pl_critair": ["pl_horaires"],


### PR DESCRIPTION
Retravaille ce qui a été introduit dans #5

`dependentRequired` est relativement récent dans la spec JSON Schema, date [du draft 2019-09](https://json-schema.org/draft/2019-09/release-notes.html#semi-incompatible-changes). 

C'est un peu trop récent pour que certains outils, en particulier des validateurs, puissent utiliser ce nom de champ. Cette PR utilise donc l'ancien nom, qui reste valide.

> The old syntax for these keywords is not an error (and the default meta-schema still validates them), so implementations can therefore offer a compatibility mode. However, migrating to the new keywords is straightforward and should be preferred.
>> `dependencies` has been split into `dependentSchemas` and `dependentRequired`